### PR TITLE
More compatable config without warnings and errors in log

### DIFF
--- a/examples/sipcapture/kamailio.cfg
+++ b/examples/sipcapture/kamailio.cfg
@@ -24,8 +24,6 @@ listen=udp:127.0.0.1:9060
 #Max loops
 max_while_loops=100
 
-mpath="/usr/local/lib64/kamailio/modules"
-
 loadmodule "pv.so"
 loadmodule "db_mysql.so"
 loadmodule "sipcapture.so"
@@ -34,6 +32,7 @@ loadmodule "rtimer.so"
 loadmodule "xlog.so"
 loadmodule "sqlops.so"
 loadmodule "htable.so"
+loadmodule "tm.so"
 loadmodule "sl.so"
 loadmodule "siputils.so"
 
@@ -44,14 +43,16 @@ modparam("htable", "htable", "b=>size=8;autoexpire=31")
 modparam("rtimer", "timer", "name=ta;interval=60;mode=1;")
 modparam("rtimer", "exec", "timer=ta;route=TIMER_STATS")
 
-modparam("sqlops","sqlcon","cb=>mysql://homer_user:homer_pass@127.0.0.1/homer_statistic")
+modparam("sqlops","sqlcon","cb=>mysql://homer_user:homer_password@127.0.0.1/homer_statistic")
 
 # ----- mi_fifo params -----
 
 ####### Routing Logic ########
-modparam("sipcapture", "db_url", "mysql://homer_user:homer_pass@127.0.0.1/homer_data")
+modparam("sipcapture", "db_url", "mysql://homer_user:homer_password@127.0.0.1/homer_data")
 modparam("sipcapture", "capture_on", 1)
 modparam("sipcapture", "hep_capture_on", 1)
+modparam("sipcapture", "insert_retries", 5)
+modparam("sipcapture", "insert_retry_timeout", 10)
 
 #Stats time
 stats.min = 5 desc "My stats TIME min"


### PR DESCRIPTION
Fixed default homer db user and password.
Removed mpath, because of platform dependence.
Added loding of tm.so before loading of sl.so.
Added siptrace retry parameters to avoid sipcapture initialization error.